### PR TITLE
chg: Update AVR workflow to use latest

### DIFF
--- a/.github/workflows/avr.yml
+++ b/.github/workflows/avr.yml
@@ -14,7 +14,7 @@ run-name: ${{ github.actor }}'s close of PR ${{ github.ref_name }} has started t
 
 jobs:
   wf-selector:
-    uses: kohirens/version-release/.github/workflows/selector.yml@5.1.1
+    uses: kohirens/version-release/.github/workflows/selector.yml@e327d431f54e299bdcefcec1febc08eb71be02ff
     name: workflow-selector
     secrets:
       github_write_token: ${{ secrets.GH_WRITE_TOKEN }}


### PR DESCRIPTION
Updated the AVR to use an edge release to fix the issue with the latest version of the AVR toolchain.